### PR TITLE
fix: Bump node version to 24, and provide better feedback regarding scan-types

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,5 +40,5 @@ outputs:
   scan-message:
     description: 'Scan message for requested scan.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ function verifyInputs(websiteIdInput, scanTypeInput, userIdInput, apiTokenInput,
   }
 
   if (!isScanTypeValid(scanType)) {
-    core.setFailed(`Input scan-type is not valid: ${scanTypeInput}`);
+    core.setFailed(`Input scan-type is not valid: ${scanTypeInput} (valid values: ${Object.values(scanTypes).join(', ')})`);
     return -1;
   }
 
@@ -241,7 +241,7 @@ function verifyInputs(websiteIdInput, scanTypeInput, userIdInput, apiTokenInput,
   }
 
   if (!isVulnerabilityLevelValid(failOnLevel)) {
-    core.setFailed(`Input fail-on-level is not valid: ${failOnLevel}`);
+    core.setFailed(`Input fail-on-level is not valid: ${failOnLevel} (valid values: ${Object.values(SEVERITY_LEVELS).join(', ')})`);
     return -1;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netsparker-enterprise-scan-action",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netsparker-enterprise-scan-action",
-      "version": "1.0.1",
+      "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "4.0.0",
@@ -473,7 +473,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2158,7 +2157,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
       "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netsparker-enterprise-scan-action",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
[Node20 is EOL](https://nodejs.org/en/about/previous-releases), and therefore throwing warnings in GH Actions.  This PR bumps the node version to 24 for better support.

Additionally, it also now reports on the correct scan types, as it was frustrating not having those documented specifically - this hopefully helps folks to know that the types are case-sensitive.

